### PR TITLE
Made posts in home page center

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -37,7 +37,7 @@ export default function Home() {
         {posts && posts.length > 0 && (
           <div className='flex flex-col gap-6'>
             <h2 className='text-2xl font-semibold text-center'>Recent Posts</h2>
-            <div className='flex flex-wrap gap-4'>
+            <div className='flex justify-center flex-wrap gap-4'>
               {posts.map((post) => (
                 <PostCard key={post._id} post={post} />
               ))}


### PR DESCRIPTION
Previously the recent posts in home page are slightly towards the left. I made them center. See the posts under "Recent Posts" in https://blog.100jsprojects.com/.
