### PR TITLE
fix sort by latest/newest posts in getposts function inside post controller

### DIFF
--- a/api/controllers/post.controller.js
+++ b/api/controllers/post.controller.js
@@ -30,7 +30,7 @@ export const getposts = async (req, res, next) => {
   try {
     const startIndex = parseInt(req.query.startIndex) || 0;
     const limit = parseInt(req.query.limit) || 9;
-    const sortDirection = req.query.order === 'asc' ? 1 : -1;
+    const sortDirection = req.query.sort === 'asc' ? 1 : -1;
     const posts = await Post.find({
       ...(req.query.userId && { userId: req.query.userId }),
       ...(req.query.category && { category: req.query.category }),


### PR DESCRIPTION
You might have noticed that the sort by latest/newest doesn't work in our search page. (You can test it in the hosted main project) It is due to a small typo in the post controller getposts function. Instead of "order" we are actually passing "sort" from our search page. So we want our getposts function to look for the value of sort not order. 