### PR TITLE
the loading after showing error message.

### DIFF
--- a/client/src/pages/SignUp.jsx
+++ b/client/src/pages/SignUp.jsx
@@ -25,6 +25,7 @@ export default function SignUp() {
         body: JSON.stringify(formData),
       });
       const data = await res.json();
+      setLoading(false);
       if (data.success === false) {
         return setErrorMessage(data.message);
       }


### PR DESCRIPTION
If the user is already existed, the error message was showing at the same time The load is continuously loading, not stopping. By adding this line, we can stop after showing the error message. The user can edit their username and try to sign up.